### PR TITLE
fix(translator): get module ID correctly

### DIFF
--- a/lib/translator.php
+++ b/lib/translator.php
@@ -44,7 +44,7 @@ class translator {
                 $slices = rex_article_slice::getSlicesForArticle($artId['id'], $langId);
 
                 foreach ($slices as $slice) {
-                    $module_id = $slice->getValue('module_id');
+                    $module_id = $slice->getModuleId();
                     if (!is_array($modulesConfig[$module_id]) || $modulesConfig[$module_id][0] == '')
                         continue;
                     // Für jeden in der Konfiguration definierten value des Slices den Wert auslesen


### PR DESCRIPTION
Beim Exportieren von TXT-Dateien wurde in der aktuellen Redaxo-Version (5.15.1) immer eine leere Datei ausgegeben, da die Variable `$module_id` immer `0` war. Dieser Fix stellt sicher, dass die Modul-ID korrekt ist und die TXT-Datei die gewünschte Ausgabe enthält.